### PR TITLE
Proper float representation in tests

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        lua: [lua=5.1, lua=5.2, lua=5.3, lua=5.4, luajit=2.0, luajit=@v2.1]
+        lua: [lua=5.1, lua=5.2, lua=5.3, lua=5.4, luajit=@v2.0, luajit=@v2.1]
     steps:
       - name: Fail on Draft PRs
         if: github.event.pull_request.draft == true
@@ -22,6 +22,9 @@ jobs:
         with:
           go-version: '>=1.19'
 
+      - name: Install libreadline
+        run: sudo apt-get install -y libreadline-dev
+
       - name: Install Lua (${{ matrix.lua }})
         run: |
           pip install hererocks
@@ -29,7 +32,7 @@ jobs:
           echo lua_install/bin >> $GITHUB_PATH
 
       - name: Install toml-test
-        run: go install github.com/toml-lang/toml-test/cmd/toml-test@v1.5.0
+        run: go install github.com/toml-lang/toml-test/cmd/toml-test@v1.6.0
     
       - name: install depedencies
         run: |

--- a/spec/toml-test.lua
+++ b/spec/toml-test.lua
@@ -9,7 +9,7 @@ local to_inf_and_beyound = {
 }
 
 
-local function floatToString(x)
+local function float_to_string(x)
 
 
    if to_inf_and_beyound[tostring(x)] then
@@ -28,7 +28,7 @@ end
 
 local assign_value_function = function(value, value_type)
    if value_type == "float" then
-      return { ["value"] = floatToString(value), ["type"] = value_type }
+      return { ["value"] = float_to_string(value), ["type"] = value_type }
    else
       return { ["value"] = tostring(value), ["type"] = value_type }
    end

--- a/spec/toml-test.lua
+++ b/spec/toml-test.lua
@@ -1,9 +1,37 @@
 local cjson = require("cjson")
 local tinytoml = require("tinytoml")
 
+local to_inf_and_beyound = {
+   ["inf"] = true,
+   ["-inf"] = true,
+   ["nan"] = true,
+   ["-nan"] = true,
+}
+
+
+local function floatToString(x)
+
+
+   if to_inf_and_beyound[tostring(x)] then
+      return tostring(x)
+   end
+   for precision = 15, 17 do
+
+      local s = ('%%.%dg'):format(precision):format(x)
+
+      if tonumber(s) == x then
+         return s
+      end
+   end
+end
+
 
 local assign_value_function = function(value, value_type)
-   return { ["value"] = tostring(value), ["type"] = value_type }
+   if value_type == "float" then
+      return { ["value"] = floatToString(value), ["type"] = value_type }
+   else
+      return { ["value"] = tostring(value), ["type"] = value_type }
+   end
 end
 
 print(cjson.encode(tinytoml.parse(io.read("*a"), { load_from_string = true, assign_value_function = assign_value_function })))

--- a/spec/toml-test.tl
+++ b/spec/toml-test.tl
@@ -1,9 +1,37 @@
 local cjson = require("cjson")
 local tinytoml = require("tinytoml")
 
+local to_inf_and_beyound = {
+   ["inf"] = true,
+   ["-inf"] = true,
+   ["nan"] = true,
+   ["-nan"] = true
+}
+
+-- Using a slightly modified version from https://stackoverflow.com/a/69827191
+local function floatToString(x)
+   -- a table key can't be nan in Lua, and I would've rather checked for equality with
+   -- math.huge/nan (as 0/0), but (0/0) != (0/0) in Lua so I think this is probably fine.
+   if to_inf_and_beyound[tostring(x)] then
+      return tostring(x)
+   end
+   for precision = 15, 17 do
+      -- Use a 2-layer format to try different precisions with %g.
+      local s <const> = ('%%.%dg'):format(precision):format(x)
+      -- See if s is an exact representation of x.
+      if tonumber(s) == x then
+         return s
+      end
+   end
+end
+
 -- the format toml-test expects
 local assign_value_function = function(value: any, value_type?: string): any 
-    return {["value"]=tostring(value), ["type"]=value_type} 
+   if value_type == "float" then
+      return {["value"]=floatToString(value), ["type"]=value_type}
+   else
+      return {["value"]=tostring(value), ["type"]=value_type} 
+   end
 end
 
 print(cjson.encode(tinytoml.parse(io.read("*a"), {load_from_string=true, assign_value_function=assign_value_function})))

--- a/spec/toml-test.tl
+++ b/spec/toml-test.tl
@@ -9,7 +9,7 @@ local to_inf_and_beyound = {
 }
 
 -- Using a slightly modified version from https://stackoverflow.com/a/69827191
-local function floatToString(x)
+local function float_to_string(x)
    -- a table key can't be nan in Lua, and I would've rather checked for equality with
    -- math.huge/nan (as 0/0), but (0/0) != (0/0) in Lua so I think this is probably fine.
    if to_inf_and_beyound[tostring(x)] then
@@ -28,7 +28,7 @@ end
 -- the format toml-test expects
 local assign_value_function = function(value: any, value_type?: string): any 
    if value_type == "float" then
-      return {["value"]=floatToString(value), ["type"]=value_type}
+      return {["value"]=float_to_string(value), ["type"]=value_type}
    else
       return {["value"]=tostring(value), ["type"]=value_type} 
    end


### PR DESCRIPTION
Floats are now encoded correctly for the unit tests as reported in #6 