### PR TITLE
Fixed error with non-exact unicode escapes and only whitespace files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ tinytoml is a pure Lua [TOML](https://toml.io) parsing library. It's written in 
 
 tinytoml passes all the [toml-test](https://github.com/toml-lang/toml-test) [use cases](https://toml-lang.github.io/toml-test-matrix/) that Lua can realistically pass (even the UTF-8 ones!). The few that fail are mostly representational:
 - Lua doesn't differentiate between an array or a dictionary, so tests involving _empty_ arrays fail.
-- Some Lua versions have differences in how numbers are represented. Lua 5.3+ introduced integers, so tests involving integer representation pass.
+- Some Lua versions have differences in how numbers are represented. Lua 5.3 introduced integers, so tests involving integer representation pass on newer versions.
 - tinytoml currently support trailing commas in arrays/inline-tables. This is coming in TOML 1.1.0.
 
 Current Supported TOML Version: 1.0.0

--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 # tinytoml
 [![Run Tests and Code Coverage](https://github.com/FourierTransformer/tinytoml/actions/workflows/test-and-coverage.yml/badge.svg)](https://github.com/FourierTransformer/tinytoml/actions/workflows/test-and-coverage.yml) [![Coverage Status](https://coveralls.io/repos/github/FourierTransformer/tinytoml/badge.svg?branch=refs/pull/1/merge)](https://coveralls.io/github/FourierTransformer/tinytoml?branch=main)
 
-tinytoml is a pure Lua [TOML](https://toml.io) parsing library. It's written in [Teal](https://github.com/teal-language/tl) and works with Lua 5.1-5.4 and LuaJIT 2.0/2.1. tinytoml parses a TOML document into a standard Lua table using default Lua types. Since TOML supports various datetime types, those are _defaultly_ represented by strings, but can be configured to use a custom type if desired.
+tinytoml is a pure Lua [TOML](https://toml.io) parsing library. It's written in [Teal](https://github.com/teal-language/tl) and works with Lua 5.1-5.4 and LuaJIT 2.0/2.1. tinytoml parses a TOML document into a standard Lua table using default Lua types. Since TOML supports various datetime types, those are by default represented by strings, but can be configured to use a custom type if desired.
 
-tinytoml passes all the [toml-test](https://github.com/toml-lang/toml-test) use cases that Lua can realistically pass (even the UTF-8 ones!). The few that fail are mostly representational:
+tinytoml passes all the [toml-test](https://github.com/toml-lang/toml-test) [use cases](https://toml-lang.github.io/toml-test-matrix/) that Lua can realistically pass (even the UTF-8 ones!). The few that fail are mostly representational:
 - Lua doesn't differentiate between an array or a dictionary, so tests involving _empty_ arrays fail.
-- Some Lua versions have differences in how numbers are represented
+- Some Lua versions have differences in how numbers are represented. Lua 5.3+ introduced integers, so tests involving integer representation pass.
 - tinytoml currently support trailing commas in arrays/inline-tables. This is coming in TOML 1.1.0.
 
 Current Supported TOML Version: 1.0.0
 
-## Implemented and Missing Features
-- TOML Parsing in Pure Lua, just grab the tinytoml.lua file and go!
-- Does not keep track of comments
+## Missing Features
 - Cannot encode a table to TOML
+- Does not keep track of comments
 
 ## Installing
 You can grab the `tinytoml.lua` file from this repo (or the `tinytoml.tl` file if using Teal) or install it via LuaRocks

--- a/tinytoml-0.0.3-1.rockspec
+++ b/tinytoml-0.0.3-1.rockspec
@@ -1,9 +1,9 @@
 package = "tinytoml"
-version = "0.0.2-1"
+version = "0.0.3-1"
 
 source = {
     url = "git://github.com/FourierTransformer/tinytoml.git",
-    tag = "0.0.2"
+    tag = "0.0.3"
 }
 
 description = {

--- a/tinytoml.lua
+++ b/tinytoml.lua
@@ -297,18 +297,18 @@ local function handle_backslash_escape(sm)
    end
 
 
-   sm._, sm.end_seq, sm.match, sm.ext = sm.input:find("^([uU])([0-9a-fA-F]+)", sm.i + 1)
-   if sm.match then
 
-      if (sm.match == "u" and #sm.ext == 4) or
-         (sm.match == "U" and #sm.ext == 8) then
-         local codepoint_to_insert = _utf8char(tonumber(sm.ext, 16))
-         if not validate_utf8(codepoint_to_insert) then
-            _error(sm, "Escaped UTF-8 sequence not valid UTF-8 character: \\" .. sm.match .. sm.ext, "string")
-         end
-         sm.i = sm.end_seq
-         return codepoint_to_insert, false
+   sm._, sm.end_seq, sm.match, sm.ext = sm.input:find("^(u)([0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])", sm.i + 1)
+   if not sm.match then
+      sm._, sm.end_seq, sm.match, sm.ext = sm.input:find("^(U)([0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])", sm.i + 1)
+   end
+   if sm.match then
+      local codepoint_to_insert = _utf8char(tonumber(sm.ext, 16))
+      if not validate_utf8(codepoint_to_insert) then
+         _error(sm, "Escaped UTF-8 sequence not valid UTF-8 character: \\" .. sm.match .. sm.ext, "string")
       end
+      sm.i = sm.end_seq
+      return codepoint_to_insert, false
    end
 
    return nil
@@ -1084,6 +1084,10 @@ function tinytoml.parse(filename, options)
    local dynamic_next_mode = "start_of_line"
    local transition = nil
    sm._, sm.i = sm.input:find("[^ \t]", sm.i)
+
+
+   if not sm.i then return {} end
+
    while sm.i <= sm.input_length do
       sm.byte = sbyte(sm.input, sm.i)
 

--- a/tinytoml.tl
+++ b/tinytoml.tl
@@ -297,18 +297,18 @@ local function handle_backslash_escape(sm: StateMachine): string, boolean
     end
 
     -- unicode escape sequences
-    sm._, sm.end_seq, sm.match, sm.ext = sm.input:find("^([uU])([0-9a-fA-F]+)", sm.i+1) as (integer, integer, string, string)
+    -- hex escapes coming in toml 1.1.0, will need to update
+    sm._, sm.end_seq, sm.match, sm.ext = sm.input:find("^(u)([0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])", sm.i+1) as (integer, integer, string)
+    if not sm.match then
+        sm._, sm.end_seq, sm.match, sm.ext = sm.input:find("^(U)([0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])", sm.i+1) as (integer, integer, string, string)
+    end
     if sm.match then
-        --if (sm.match == "x" and #sm.ext == 2) or -- hex escapes coming in toml 1.1.0, will need to update pattern in :find above as well
-        if (sm.match == "u" and #sm.ext == 4) or
-           (sm.match == "U" and #sm.ext == 8) then
-            local codepoint_to_insert = _utf8char(tonumber(sm.ext, 16))
-            if not validate_utf8(codepoint_to_insert) then
-                _error(sm, "Escaped UTF-8 sequence not valid UTF-8 character: \\" .. sm.match .. sm.ext, "string")
-            end
-            sm.i = sm.end_seq
-            return codepoint_to_insert, false
+        local codepoint_to_insert = _utf8char(tonumber(sm.ext, 16))
+        if not validate_utf8(codepoint_to_insert) then
+            _error(sm, "Escaped UTF-8 sequence not valid UTF-8 character: \\" .. sm.match .. sm.ext, "string")
         end
+        sm.i = sm.end_seq
+        return codepoint_to_insert, false
     end
 
     return nil
@@ -1084,6 +1084,10 @@ function tinytoml.parse(filename: string, options?: TinyTomlOptions): {string:an
     local dynamic_next_mode: states = "start_of_line"
     local transition: {function, string} = nil
     sm._, sm.i = sm.input:find("[^ \t]", sm.i)
+
+    -- just an file with whitespace and nothing else...
+    if not sm.i then return {} end
+    
     while sm.i <= sm.input_length do
         sm.byte = sbyte(sm.input, sm.i)
 


### PR DESCRIPTION
- tinytoml used to look for any `([uU])([0-9a-fA-F]+)`, which could match with `\u002edot` since they are all in the pattern and then wouldn't pass the length check of 4 and assume it's invalid unicode.
  - Now tinytoml will explicitly check of `(u)([0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])` (and `U` with 8 charactars) and perform the unicode translation, so in the example above it would _only match_ `\u002e` and leave the rest alone.
- tinytoml wouldn't return an empty table for a file with only whitespace
  - By checking if no characters are found at the beginning of the parse, we can account for this.

Thanks to @arp242 in #6 for the heads up!